### PR TITLE
Errores de session

### DIFF
--- a/system/libraries/Session/Session.php
+++ b/system/libraries/Session/Session.php
@@ -140,7 +140,7 @@ class CI_Session {
 			unset($_COOKIE[$this->_config['cookie_name']]);
 		}
 
-		session_start();
+		// session_start();
 
 		// Is session ID auto-regeneration configured? (ignoring ajax requests)
 		if ((empty($_SERVER['HTTP_X_REQUESTED_WITH']) OR strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) !== 'xmlhttprequest')


### PR DESCRIPTION
En esta rama se resolvieron los errores de session, comentando en la libreria session_start(). Ojo es recomendable revisar las librerias que tiene codeigniter por defecto para saber si funciona dichas librerias